### PR TITLE
Add edit and event links to the Admin RSVP list view

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -4,8 +4,6 @@ from django.utils.html import format_html
 
 from .models import RSVP, Event
 
-admin.site.register(RSVP)
-
 
 @admin.register(Event)
 class EventAdmin(admin.ModelAdmin):
@@ -23,4 +21,28 @@ class EventAdmin(admin.ModelAdmin):
     def edit_link(self, event):
         """Link to the event detail page."""
         url = reverse("events:update", kwargs={"pk": event.id}) + "?" + "secret=" + event.secret()
+        return format_html('<a href="{}">Edit</a>', url)
+
+
+@admin.register(RSVP)
+class RSVPAdmin(admin.ModelAdmin):
+    list_display = ["name", "event_link", "edit_link"]
+
+    class Meta:
+        model = RSVP
+        fields = "__all__"
+
+    def event_link(self, rsvp):
+        """Link to the event detail page."""
+        url = reverse("events:detail", kwargs={"pk": rsvp.event.id})
+        return format_html('<a href="{}">{}</a>', url, rsvp.event.title)
+
+    def edit_link(self, rsvp):
+        """Link to the rsvp detail page."""
+        url = (
+            reverse("events:rsvp_update", kwargs={"event_id": rsvp.event.id, "pk": rsvp.id})
+            + "?"
+            + "secret="
+            + rsvp.secret()
+        )
         return format_html('<a href="{}">Edit</a>', url)


### PR DESCRIPTION
Cleans up the admin view for RSVPs so we have edit and event links in there.

<img width="1301" alt="image" src="https://user-images.githubusercontent.com/693546/163692917-222517b7-2835-4512-841c-496a63f372ed.png">
