### PR TITLE
Force webserver to redirect to HTTPS

### DIFF
--- a/planner/settings.py
+++ b/planner/settings.py
@@ -50,6 +50,7 @@ else:
     payload = client.access_secret_version(name=name).payload.data.decode("UTF-8")
     env.read_env(io.StringIO(payload))
 
+SECURE_SSL_REDIRECT = !LOCAL
 SECRET_KEY = env("SECRET_KEY")
 
 # SECURITY WARNING: App Engine's security features ensure that it is safe to


### PR DESCRIPTION
Currently if you go to say `smol.party/e/<event_id>/` without including `https://` in the URL, the webserver will server the request over HTTP instead of HTTPS, which is bad!

Not exactly sure how smol.party is currently deployed but there's a chance that this causes an issue (see the `Note` at https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SECURE_SSL_REDIRECT). And in general this might be something that should be configured at the root web server level eg. in NGINX instead (and if so feel free to reject this PR).