### PR TITLE
Let users add raw html with the WYSIWYG editor

### DIFF
--- a/events/templates/events/event/create_update.html
+++ b/events/templates/events/event/create_update.html
@@ -129,6 +129,14 @@
                         'ulist',
                         'image',
                         'link',
+                        {
+                          icon: '&#9998;',
+                          title: 'Insert HTML',
+                          result: () => {
+                            const url = window.prompt('Enter HTML');
+                            if (url) document.execCommand('insertHTML',false, url)
+                          }
+                        }
                     ],
                     // Define the content class differently or else the unset breaks things.
                     classes: {


### PR DESCRIPTION
This adds a really janky button to the editor that lets you insert raw HTML. Nifty for doing things like inserting an inframe of your Friendsgiving spreadsheet.

<img width="928" alt="image" src="https://user-images.githubusercontent.com/693546/197906799-3a9fc16a-054b-4cd7-9062-a3692fecad5b.png">
