### PR TITLE
Disable submit button on RSVP form after submission

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -8,6 +8,7 @@ from .models import RSVP, Event
 @admin.register(Event)
 class EventAdmin(admin.ModelAdmin):
     list_display = ["title", "details_link", "edit_link"]
+    ordering = ["-created_at"]
 
     class Meta:
         model = Event
@@ -27,6 +28,7 @@ class EventAdmin(admin.ModelAdmin):
 @admin.register(RSVP)
 class RSVPAdmin(admin.ModelAdmin):
     list_display = ["name", "event_link", "edit_link"]
+    ordering = ["-created_at"]
 
     class Meta:
         model = RSVP

--- a/events/templates/events/rsvp/create_update.html
+++ b/events/templates/events/rsvp/create_update.html
@@ -22,15 +22,9 @@
                         <hr>
                         <center><small>Or, <a href="{% url 'events:rsvp_delete' event.id rsvp.id %}?secret={{ rsvp.secret }}">click here</a> to delete your RSVP.</small></center>
                     {% else %}
-                        <input type="submit" value="Submit" id="submit">
+                        <input type="submit" value="Submit" id="submit" onSubmit="document.getElementById('submit').disabled=true;">
                     {% endif %}
                 </form>
             </article>
         </main>
-
-	<script>
-		const button = document.querySelector("#submit");
-		const disableButton = () => { button.disabled = true; };
-		button.addEventListener("click", disableButton);
-	</script>
     </body>

--- a/events/templates/events/rsvp/create_update.html
+++ b/events/templates/events/rsvp/create_update.html
@@ -22,9 +22,15 @@
                         <hr>
                         <center><small>Or, <a href="{% url 'events:rsvp_delete' event.id rsvp.id %}?secret={{ rsvp.secret }}">click here</a> to delete your RSVP.</small></center>
                     {% else %}
-                        <input type="submit" value="Submit">
+                        <input type="submit" value="Submit" id="submit">
                     {% endif %}
                 </form>
             </article>
         </main>
+
+	<script>
+		const button = document.querySelector("#submit");
+		const disableButton = () => { button.disabled = true; };
+		button.addEventListener("click", disableButton);
+	</script>
     </body>


### PR DESCRIPTION
Some people were mashing the submit button and creating duplicate RSVPs. This disables that.